### PR TITLE
Default 250 boxes per shipment with 50 step

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@
   
   // Step 1 inputs
   let pricePerBox = 0.9;           // Kosten per kartonnen doos
-  let boxesPerShipment = 10;       // Dozen per vracht
+  let boxesPerShipment = 250;       // Dozen per vracht
   let shipmentsPerWeek = 3;        // Aantal leveringen per week
   
   // Fixed values for Step 2
@@ -235,7 +235,7 @@
             <div class="step-inputs-section">
               <div class="grid grid-cols-3 gap-6">
                 ${numberInput('pricePerBox', pricePerBox, 'Price per cardboard box (180 eggs)', '€', 0.01)}
-                ${numberInput('boxesPerShipment', boxesPerShipment, 'Boxes per shipment', '', 1, 1)}
+                ${numberInput('boxesPerShipment', boxesPerShipment, 'Boxes per shipment', '', 50, 50)}
                 ${numberInput('shipmentsPerWeek', shipmentsPerWeek, 'Shipments per week', '', 1, 1)}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Set default boxes per shipment to 250
- Adjust boxes-per-shipment controls to change in steps of 50

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c125455600832cab7ecb6c533f02c5