### PR TITLE
Enable automatic dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Crate 
-                Savings Calculator</title>
+  <meta name="color-scheme" content="light dark" />
+  <title>Crate Savings Calculator</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,5 @@
 #ecs-calc, #ecs-calc * { box-sizing: border-box; }
-  #ecs-calc { font-family:-apple-system, BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; color:#111827; line-height:1.6; }
+  #ecs-calc { font-family:-apple-system, BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; color:#111827; line-height:1.6; color-scheme: light dark; }
   #ecs-calc svg { display:inline-block; vertical-align:middle; }
   #ecs-calc button, #ecs-calc input, #ecs-calc label { font-family:inherit; }
   #ecs-calc a { color:inherit; text-decoration:none; }
@@ -353,5 +353,17 @@
     #ecs-calc .bg-gradient-to-r .justify-between{justify-content:center}
     #ecs-calc .cost-comparison-values{flex-direction:column;gap:1rem}
     #ecs-calc .vs-divider{display:none}
-    #ecs-calc .savings-metrics{grid-template-columns:1fr}
+  #ecs-calc .savings-metrics{grid-template-columns:1fr}
+  }
+
+  /* Dark mode */
+  @media (prefers-color-scheme: dark){
+    #ecs-calc { color:#f3f4f6; }
+    #ecs-calc .bg-gradient-to-br{background:linear-gradient(135deg,#111827 0%,#1f2937 100%)}
+    #ecs-calc .bg-white{background:#1f2937}
+    #ecs-calc .bg-gradient-to-r{background:linear-gradient(135deg,#1f2937 0%,#0f172a 100%)}
+    #ecs-calc .text-gray-600{color:#d1d5db}
+    #ecs-calc .text-gray-700{color:#e5e7eb}
+    #ecs-calc .nav-btn{background:#374151;border-color:#4b5563;color:#f3f4f6}
+    #ecs-calc .nav-btn:hover:not(:disabled){border-color:#4b5563;color:#fff}
   }


### PR DESCRIPTION
## Summary
- add automatic dark-mode support using `prefers-color-scheme`
- expose color-scheme metadata for better native styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c13fc3a234832cb5accdfaeceb699b