### PR TITLE
Improve dark mode styling for calculator blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
           <div class="min-h-400" id="ecs-stepContent"></div>
 
           <!-- Navigation -->
-          <div class="flex justify-between items-center" style="margin-top:35px;padding-top:1.5rem;border-top:1px solid #e5e7eb">
+          <div class="flex justify-between items-center nav-container">
             <button id="ecs-prevBtn" class="nav-btn prev" disabled>
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path></svg>
               <span>Previous</span>

--- a/script.js
+++ b/script.js
@@ -245,7 +245,7 @@
         html = `
           <div class="${wrapClass}">
             <div class="step-header-section">
-              <div class="inline-flex items-center justify-center w-16 h-16 bg-blue-100 rounded-full mb-4" style="background:#dbeafe">${icon('Package','w-8 h-8 text-blue-600')}</div>
+              <div class="inline-flex items-center justify-center w-16 h-16 rounded-full mb-4 icon-bg-blue">${icon('Package','w-8 h-8 text-blue-600')}</div>
               <h2 class="text-2xl font-bold mb-2">Step 1: Current Packaging Costs</h2>
               <p class="text-gray-600">Enter your current packaging costs and delivery frequency</p>
             </div>
@@ -279,7 +279,7 @@
         html = `
           <div class="${wrapClass}">
             <div class="step-header-section">
-              <div class="inline-flex items-center justify-center w-16 h-16 rounded-full mb-4" style="background:#dcfce7">${icon('Recycle','w-8 h-8 text-blue-600')}</div>
+              <div class="inline-flex items-center justify-center w-16 h-16 rounded-full mb-4 icon-bg-green">${icon('Recycle','w-8 h-8 text-blue-600')}</div>
               <h2 class="text-2xl font-bold mb-2">Step 2: Crate Solution</h2>
               <p class="text-gray-600">Sustainable crates that last 10 years and eliminate the need for cardboard trays</p>
             </div>
@@ -328,7 +328,7 @@
         html = `
           <div class="${wrapClass}">
             <div class="step-header-section">
-              <div class="inline-flex items-center justify-center w-16 h-16 rounded-full mb-4" style="background:#ffedd5">
+              <div class="inline-flex items-center justify-center w-16 h-16 rounded-full mb-4 icon-bg-orange">
                 ${icon('Calculator','w-8 h-8 text-blue-600')}
               </div>
               <h2 class="text-2xl font-bold mb-2">Step 3: Cost Comparison & Savings</h2>
@@ -338,28 +338,28 @@
             <div class="step-info-section">
               
               <!-- Total Savings Summary -->
-              <div style="background:linear-gradient(135deg,#f0fdf4 0%,#dcfce7 100%);border:0px;border-radius:1rem;padding:1.5rem;position:relative;overflow:hidden">
-                <div style="display:flex;align-items:center;gap:.75rem;margin-bottom:1.25rem">
+              <div class="savings-summary">
+                <div class="savings-summary-header">
                   ${icon('DollarSign','w-6 h-6')}
-                  <span style="font-size:1.25rem;font-weight:800;color:#14532d">Your Total Savings with crates</span>
+                  <span class="savings-summary-title">Your Total Savings with crates</span>
                 </div>
                 <div class="savings-metrics">
-                  <div style="text-align:center;padding:1rem;background:rgba(255,255,255,.9);border-radius:.75rem">
-                    <p style="font-size:.75rem;text-transform:uppercase;letter-spacing:.05em;color:#15803d;margin-bottom:.5rem;font-weight:600">Save per Week</p>
-                    <p style="font-size:1.75rem;font-weight:900;color:#14532d;line-height:1">€${fmt(calculations.savingsPerWeek)}</p>
+                  <div class="savings-metric">
+                    <p class="savings-metric-label">Save per Week</p>
+                    <p class="savings-metric-value">€${fmt(calculations.savingsPerWeek)}</p>
                   </div>
-                  <div style="text-align:center;padding:1rem;background:rgba(255,255,255,.9);border-radius:.75rem">
-                    <p style="font-size:.75rem;text-transform:uppercase;letter-spacing:.05em;color:#15803d;margin-bottom:.5rem;font-weight:600">Save per Year</p>
-                    <p style="font-size:1.75rem;font-weight:900;color:#14532d;line-height:1">€${fmt(calculations.savingsPerYear)}</p>
+                  <div class="savings-metric">
+                    <p class="savings-metric-label">Save per Year</p>
+                    <p class="savings-metric-value">€${fmt(calculations.savingsPerYear)}</p>
                   </div>
-                  <div style="text-align:center;padding:1rem;background:rgba(255,255,255,.9);border-radius:.75rem">
-                    <p style="font-size:.75rem;text-transform:uppercase;letter-spacing:.05em;color:#15803d;margin-bottom:.5rem;font-weight:600">Save per Month</p>
-                    <p style="font-size:1.75rem;font-weight:900;color:#14532d;line-height:1">€${fmt(calculations.monthlySavings)}</p>
+                  <div class="savings-metric">
+                    <p class="savings-metric-label">Save per Month</p>
+                    <p class="savings-metric-value">€${fmt(calculations.monthlySavings)}</p>
                   </div>
                 </div>
-                <div style="text-align:center;margin-top:1.25rem;padding-top:1.25rem;border-top:2px solid rgba(134,239,172,.3)">
-                  <p style="font-size:.875rem;color:#15803d;margin-bottom:.5rem">Total savings over 10 years</p>
-                  <p id="ecs-totalSavings" style="font-size:2.5rem;font-weight:900;color:#14532d;line-height:1">€0.00</p>
+                <div class="savings-summary-footer">
+                  <p>Total savings over 10 years</p>
+                  <p id="ecs-totalSavings">€0.00</p>
                 </div>
               </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -149,6 +149,20 @@
   #ecs-calc .savings-value{font-size:1.5rem;font-weight:800;color:#14532d}
   #ecs-calc .savings-metrics{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem}
 
+  #ecs-calc .nav-container{margin-top:35px;padding-top:1.5rem;border-top:1px solid #e5e7eb}
+  #ecs-calc .savings-summary{background:linear-gradient(135deg,#f0fdf4 0%,#dcfce7 100%);border:0px;border-radius:1rem;padding:1.5rem;position:relative;overflow:hidden}
+  #ecs-calc .savings-summary-header{display:flex;align-items:center;gap:.75rem;margin-bottom:1.25rem}
+  #ecs-calc .savings-summary-title{font-size:1.25rem;font-weight:800;color:#14532d}
+  #ecs-calc .savings-metric{text-align:center;padding:1rem;background:rgba(255,255,255,.9);border-radius:.75rem}
+  #ecs-calc .savings-metric-label{font-size:.75rem;text-transform:uppercase;letter-spacing:.05em;color:#15803d;margin-bottom:.5rem;font-weight:600}
+  #ecs-calc .savings-metric-value{font-size:1.75rem;font-weight:900;color:#14532d;line-height:1}
+  #ecs-calc .savings-summary-footer{text-align:center;margin-top:1.25rem;padding-top:1.25rem;border-top:2px solid rgba(134,239,172,.3)}
+  #ecs-calc .savings-summary-footer p{font-size:.875rem;color:#15803d;margin-bottom:.5rem}
+  #ecs-calc #ecs-totalSavings{font-size:2.5rem;font-weight:900;color:#14532d;line-height:1}
+  #ecs-calc .icon-bg-blue{background:#dbeafe}
+  #ecs-calc .icon-bg-green{background:#dcfce7}
+  #ecs-calc .icon-bg-orange{background:#ffedd5}
+
   /* ====================================================================
      STEP 2 — CARD COMPONENT
   ==================================================================== */
@@ -366,4 +380,34 @@
     #ecs-calc .text-gray-700{color:#e5e7eb}
     #ecs-calc .nav-btn{background:#374151;border-color:#4b5563;color:#f3f4f6}
     #ecs-calc .nav-btn:hover:not(:disabled){border-color:#4b5563;color:#fff}
+    #ecs-calc .nav-container{border-top-color:#4b5563}
+    #ecs-calc .info-box.blue{background:#1e3a8a;border-color:#1e40af}
+    #ecs-calc .info-box.blue .info-box-text{color:#93c5fd}
+    #ecs-calc .info-box.blue .font-medium{color:#bfdbfe}
+    #ecs-calc .info-box.gray{background:#374151;border-color:#4b5563}
+    #ecs-calc .info-box.orange{background:#78350f;border-color:#c2410c}
+    #ecs-calc .info-box.orange .info-box-text{color:#fdba74}
+    #ecs-calc .info-box.orange .font-medium{color:#fed7aa}
+    #ecs-calc .info-box.green{background:#14532d;border-color:#15803d}
+    #ecs-calc .info-box.green .info-box-text{color:#bbf7d0}
+    #ecs-calc .info-box.green .font-medium{color:#86efac}
+    #ecs-calc .info-box.red{background:#7f1d1d;border-color:#b91c1c}
+    #ecs-calc .info-box.yellow{background:#78350f;border-color:#eab308}
+    #ecs-calc .cost-card{background:#1f2937;border-color:#374151}
+    #ecs-calc .card{background:#1f2937;border-color:#374151}
+    #ecs-calc .kpi{background:#1f2937;border-color:#374151}
+    #ecs-calc .number-input-container{background:#374151;border-color:#4b5563}
+    #ecs-calc .number-input-btn{color:#d1d5db}
+    #ecs-calc .number-input-field{color:#f3f4f6}
+    #ecs-calc .savings-summary{background:linear-gradient(135deg,#064e3b 0%,#065f46 100%)}
+    #ecs-calc .savings-summary-title{color:#d1fae5}
+    #ecs-calc .savings-metric{background:rgba(31,41,55,.9)}
+    #ecs-calc .savings-metric-label{color:#6ee7b7}
+    #ecs-calc .savings-metric-value{color:#d1fae5}
+    #ecs-calc .savings-summary-footer{border-top-color:rgba(16,185,129,.3)}
+    #ecs-calc .savings-summary-footer p{color:#6ee7b7}
+    #ecs-calc #ecs-totalSavings{color:#d1fae5}
+    #ecs-calc .icon-bg-blue{background:#1e3a8a}
+    #ecs-calc .icon-bg-green{background:#065f46}
+    #ecs-calc .icon-bg-orange{background:#78350f}
   }


### PR DESCRIPTION
## Summary
- Replace inline styling with reusable classes and add navigation container for dark theme
- Add comprehensive dark mode styles for info boxes, inputs, icons and savings summary
- Introduce structured markup for savings summary to support theme-aware styling

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_b_68c141b195c4832cacab387e81f83615