### PR TITLE
Fix dark mode styling for step 2

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -396,6 +396,12 @@
     #ecs-calc .cost-card{background:#1f2937;border-color:#374151}
     #ecs-calc .card{background:#1f2937;border-color:#374151}
     #ecs-calc .kpi{background:#1f2937;border-color:#374151}
+    #ecs-calc .card.green{background:#14532d;border-color:#15803d}
+    #ecs-calc .card.blue{background:#1e3a8a;border-color:#1e40af}
+    #ecs-calc .card.gray{background:#374151;border-color:#4b5563}
+    #ecs-calc .title{color:#f3f4f6}
+    #ecs-calc .kpi .label{color:#d1d5db}
+    #ecs-calc .help{color:#d1d5db}
     #ecs-calc .number-input-container{background:#374151;border-color:#4b5563}
     #ecs-calc .number-input-btn{color:#d1d5db}
     #ecs-calc .number-input-field{color:#f3f4f6}


### PR DESCRIPTION
## Summary
- Improve dark mode colors for step 2 cards
- Lighten labels and helper text
- Ensure card titles remain legible in dark theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c1457f2344832c90238ee6b936948d