### PR TITLE
Improve stepper appearance in dark mode

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -381,6 +381,10 @@
     #ecs-calc .nav-btn{background:#374151;border-color:#4b5563;color:#f3f4f6}
     #ecs-calc .nav-btn:hover:not(:disabled){border-color:#4b5563;color:#fff}
     #ecs-calc .nav-container{border-top-color:#4b5563}
+    #ecs-calc .bg-blue-600{background:#2563eb}
+    #ecs-calc .bg-gray-300{background:#4b5563}
+    #ecs-calc .border-gray-300{border-color:#4b5563}
+    #ecs-calc .text-blue-900{color:#93c5fd}
     #ecs-calc .info-box.blue{background:#1e3a8a;border-color:#1e40af}
     #ecs-calc .info-box.blue .info-box-text{color:#93c5fd}
     #ecs-calc .info-box.blue .font-medium{color:#bfdbfe}


### PR DESCRIPTION
## Summary
- adjust stepper indicator colors for dark mode

## Testing
- `node --check script.js`
- `npx -y prettier@2.8.8 --check index.html script.js styles.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68c14c156b98832cb528d3c5968bef1b