### PR TITLE
Fix dark mode styling for weekly packaging cost

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -397,6 +397,8 @@
     #ecs-calc .info-box.green .font-medium{color:#86efac}
     #ecs-calc .info-box.red{background:#7f1d1d;border-color:#b91c1c}
     #ecs-calc .info-box.yellow{background:#78350f;border-color:#eab308}
+    #ecs-calc .cost-display-amount{color:#f3f4f6}
+    #ecs-calc .cost-breakdown{color:#d1d5db}
     #ecs-calc .cost-card{background:#1f2937;border-color:#374151}
     #ecs-calc .card{background:#1f2937;border-color:#374151}
     #ecs-calc .kpi{background:#1f2937;border-color:#374151}


### PR DESCRIPTION
## Summary
- Ensure the price and cost breakdown in "Weekly packaging cost" remain readable in dark mode by adding specific dark mode colors.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c15a7131b0832c80489eb1366e1c39