### PR TITLE
Use lucide icons throughout navigation and currency

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,16 +33,25 @@
           <!-- Navigation -->
           <div class="flex justify-between items-center nav-container">
             <button id="ecs-prevBtn" class="nav-btn prev" disabled>
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path></svg>
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 12H5" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l-7-7 7-7" />
+              </svg>
               <span>Previous</span>
             </button>
             <button id="ecs-cta" class="cta-btn" style="display:none">
              <span>Get Your Free Quote</span>
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3"></path></svg>
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5l7 7-7 7" />
+              </svg>
             </button>
             <button id="ecs-nextBtn" class="nav-btn next">
               <span>Next Step</span>
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14" />
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5l7 7-7 7" />
+              </svg>
             </button>
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@
   const lang = navigator.language || 'en';
   const currency = lang.startsWith('en')
     ? { symbol:'$', icon:'DollarSign', locale:lang }
-    : { symbol:'€', icon:'EuroSign', locale:lang };
+    : { symbol:'€', icon:'Euro', locale:lang };
 
   // --- State ---
   let currentStep = 0;
@@ -89,15 +89,15 @@
       Calculator:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 7h6m0 10v-3m-3 3h.01M9 17h.01M9 14h.01M12 14h.01M15 11h.01M12 11h.01M9 11h.01M7 21h10a2 2 0 002-2V5a2 2 0 00-2-2H7a2 2 0 00-2 2v14a2 2 0 002 2z"/>',
       Recycle:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>',
       TrendingUp:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>',
-      DollarSign:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"/>',
-      EuroSign:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 7h-5a4 4 0 100 8h5M11 9h7M11 15h7"/>',
+      DollarSign:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 2v20"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 5H9a3 3 0 000 6h6a3 3 0 010 6H6"/>',
+      Euro:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 10h12"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 15h12"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 5h-6a5 5 0 000 10h6"/>',
       Clock:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>',
       Target:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 100 4m0-4v2m0-6V4"/>',
       CheckCircle:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>',
       BarChart3:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>',
       Truck:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16V6a1 1 0 00-1-1H4a1 1 0 00-1 1v10a1 1 0 001 1h1m8-1a1 1 0 01-1 1H9m4-1V8a1 1 0 011-1h2.586a1 1 0 01.707.293l3.414 3.414a1 1 0 01.293.707V16a1 1 0 01-1 1h-1m-6-1a1 1 0 001 1h1M5 17a2 2 0 104 0m-4 0a2 2 0 114 0m6 0a2 2 0 104 0m-4 0a2 2 0 114 0"/>',
-      Minus:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"/>',
-      Plus:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>',
+      Minus:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14"/>',
+      Plus:'<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v14"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14"/>',
       Wallet:'<path stroke-linejoin="round" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7V4a1 1 0 0 0-1-1H5a2 2 0 0 0 0 4h15a1 1 0 0 1 1 1v4h-3a2 2 0 0 0 0 4h3a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1"/><path d="M3 5v14a2 2 0 0 0 2 2h15a1 1 0 0 0 1-1v-4"/>'
     };
     return `<svg class="${cls}" fill="none" stroke="currentColor" viewBox="0 0 24 24">${p[name]||''}</svg>`;


### PR DESCRIPTION
## Summary
- replace inline navigation arrows with lucide icons
- use lucide Euro icon and unify currency/number input icons

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_b_68c161ac0fb4832ca8f8886413acc547