### PR TITLE
Reorder savings rows in cost comparison

### DIFF
--- a/script.js
+++ b/script.js
@@ -352,6 +352,10 @@
                   ${icon(currency.icon,'w-6 h-6')}
                   <span class="savings-summary-title">Your Total Savings with crates</span>
                 </div>
+                <div class="savings-summary-footer">
+                  <p>Total savings over 10 years</p>
+                  <p id="ecs-totalSavings">${currency.symbol}0.00</p>
+                </div>
                 <div class="savings-metrics">
                   <div class="savings-metric">
                     <p class="savings-metric-label">Save per Week</p>
@@ -365,10 +369,6 @@
                     <p class="savings-metric-label">Save per Year</p>
                     <p class="savings-metric-value">${currency.symbol}${fmt(calculations.savingsPerYear)}</p>
                   </div>
-                </div>
-                <div class="savings-summary-footer">
-                  <p>Total savings over 10 years</p>
-                  <p id="ecs-totalSavings">${currency.symbol}0.00</p>
                 </div>
               </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -159,7 +159,7 @@
   #ecs-calc .savings-metric{text-align:center;padding:1rem;background:rgba(255,255,255,.9);border-radius:.75rem}
   #ecs-calc .savings-metric-label{font-size:.75rem;text-transform:uppercase;letter-spacing:.05em;color:#15803d;margin-bottom:.5rem;font-weight:600}
   #ecs-calc .savings-metric-value{font-size:1.75rem;font-weight:900;color:#14532d;line-height:1}
-  #ecs-calc .savings-summary-footer{text-align:center;margin-top:1.25rem;padding-top:1.25rem;border-top:2px solid rgba(134,239,172,.3)}
+  #ecs-calc .savings-summary-footer{text-align:center;margin-bottom:1.25rem;padding-bottom:1.25rem;border-bottom:2px solid rgba(134,239,172,.3)}
   #ecs-calc .savings-summary-footer p{font-size:.875rem;color:#15803d;margin-bottom:.5rem; margin-top:.5rem}
   #ecs-calc #ecs-totalSavings{font-size:2.5rem;font-weight:900;color:#14532d;line-height:1}
   #ecs-calc .icon-bg-blue{background:#dbeafe}
@@ -427,7 +427,7 @@
     #ecs-calc .savings-metric{background:rgba(31,41,55,.9)}
     #ecs-calc .savings-metric-label{color:#6ee7b7}
     #ecs-calc .savings-metric-value{color:#d1fae5}
-    #ecs-calc .savings-summary-footer{border-top-color:rgba(16,185,129,.3)}
+    #ecs-calc .savings-summary-footer{border-bottom-color:rgba(16,185,129,.3)}
     #ecs-calc .savings-summary-footer p{color:#6ee7b7}
     #ecs-calc #ecs-totalSavings{color:#d1fae5}
     #ecs-calc .icon-bg-blue{background:#1e3a8a}


### PR DESCRIPTION
## Summary
- Show total savings above weekly, monthly, and yearly metrics in Step 3
- Adjust CSS to maintain spacing and borders for the new layout

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c2728f6948832c85e164f98def8dab